### PR TITLE
allow discovery by label as well as service

### DIFF
--- a/src/main/java/io/fabric8/elasticsearch/cloud/kubernetes/KubernetesAPIService.java
+++ b/src/main/java/io/fabric8/elasticsearch/cloud/kubernetes/KubernetesAPIService.java
@@ -16,6 +16,10 @@
 package io.fabric8.elasticsearch.cloud.kubernetes;
 
 import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.Pod;
+
+import java.util.List;
+
 import org.elasticsearch.common.component.LifecycleComponent;
 
 public interface KubernetesAPIService extends LifecycleComponent<KubernetesAPIService> {
@@ -26,10 +30,18 @@ public interface KubernetesAPIService extends LifecycleComponent<KubernetesAPISe
    * @return a collection of IP addresses for the service endpoints
    */
   Endpoints endpoints();
+  /**
+   * Return a collection of pods with specific label
+   *
+   * @return a collection of pods with specific label
+   */
+  List<Pod> pods();
 
   final class Fields {
     public static final String NAMESPACE = "cloud.kubernetes.namespace";
     public static final String SERVICE_NAME = "cloud.kubernetes.service";
+    public static final String POD_LABEL = "cloud.kubernetes.pod_label";
+    public static final String POD_PORT = "cloud.kubernetes.pod_port";
     public static final String REFRESH = "cloud.kubernetes.refresh_interval";
     public static final String VERSION = "Elasticsearch/KubernetesCloud/1.0";
 

--- a/src/main/java/io/fabric8/elasticsearch/cloud/kubernetes/KubernetesAPIServiceImpl.java
+++ b/src/main/java/io/fabric8/elasticsearch/cloud/kubernetes/KubernetesAPIServiceImpl.java
@@ -16,8 +16,12 @@
 package io.fabric8.elasticsearch.cloud.kubernetes;
 
 import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+
+import java.util.List;
+
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
@@ -28,6 +32,7 @@ public class KubernetesAPIServiceImpl extends AbstractLifecycleComponent<Kuberne
 
   private final String namespace;
   private final String serviceName;
+  private final String podLabel;
 
   @Override
   public Endpoints endpoints() {
@@ -35,6 +40,13 @@ public class KubernetesAPIServiceImpl extends AbstractLifecycleComponent<Kuberne
     return client().endpoints().inNamespace(namespace).withName(serviceName).get();
   }
 
+  @Override
+  public List<Pod> pods() {
+    logger.debug("get endpoints with pod label {}, namespace {}", podLabel, namespace);
+    final String[] l = podLabel.split("=");
+    return client().pods().inNamespace(namespace).withLabel(l[0], l[1]).list().getItems();
+  }
+  
   private KubernetesClient client;
 
   @Inject
@@ -42,6 +54,7 @@ public class KubernetesAPIServiceImpl extends AbstractLifecycleComponent<Kuberne
     super(settings);
     this.namespace = settings.get(Fields.NAMESPACE);
     this.serviceName = settings.get(Fields.SERVICE_NAME);
+    this.podLabel = settings.get(Fields.POD_LABEL);
   }
 
   public synchronized KubernetesClient client() {

--- a/src/main/java/io/fabric8/elasticsearch/plugin/discovery/kubernetes/KubernetesDiscoveryPlugin.java
+++ b/src/main/java/io/fabric8/elasticsearch/plugin/discovery/kubernetes/KubernetesDiscoveryPlugin.java
@@ -53,12 +53,13 @@ public class KubernetesDiscoveryPlugin extends Plugin {
       return false;
     }
 
-    if (!checkProperty(KubernetesAPIService.Fields.NAMESPACE, settings.get(KubernetesAPIService.Fields.NAMESPACE), logger) ||
-      !checkProperty(KubernetesAPIService.Fields.SERVICE_NAME, settings.get(KubernetesAPIService.Fields.SERVICE_NAME), logger)) {
+    if ( !hasNamespace(settings, logger) || !(hasServiceName(settings, logger) ^ hasPodLabel(settings, logger)) ) {
       logger.debug("one or more Kubernetes discovery settings are missing. " +
-          "Check elasticsearch.yml file. Should have [{}] and [{}].",
+          "Check elasticsearch.yml file. Should have [{}] and only one of [{}] or [{} : {}].",
         KubernetesAPIService.Fields.NAMESPACE,
-        KubernetesAPIService.Fields.SERVICE_NAME);
+        KubernetesAPIService.Fields.SERVICE_NAME,
+        KubernetesAPIService.Fields.POD_LABEL,
+        KubernetesAPIService.Fields.POD_PORT);
       return false;
     }
 
@@ -67,6 +68,19 @@ public class KubernetesDiscoveryPlugin extends Plugin {
     return true;
   }
 
+  private static boolean hasNamespace(Settings settings, ESLogger logger) {
+    return checkProperty(KubernetesAPIService.Fields.NAMESPACE, settings.get(KubernetesAPIService.Fields.NAMESPACE), logger);
+  }
+ 
+  private static boolean hasServiceName(Settings settings, ESLogger logger) {
+    return checkProperty(KubernetesAPIService.Fields.SERVICE_NAME, settings.get(KubernetesAPIService.Fields.SERVICE_NAME), logger);
+  }
+ 
+  private static boolean hasPodLabel(Settings settings, ESLogger logger) {
+    return checkProperty(KubernetesAPIService.Fields.POD_LABEL, settings.get(KubernetesAPIService.Fields.POD_LABEL), logger) &&
+           checkProperty(KubernetesAPIService.Fields.POD_PORT, settings.get(KubernetesAPIService.Fields.POD_PORT), logger);
+  }
+  
   private static boolean checkProperty(String name, String value, ESLogger logger) {
     if (!Strings.hasText(value)) {
       logger.warn("{} is not set.", name);


### PR DESCRIPTION
We have stumbled upon an issue with ElasticSearch cluster with a size larger than one, its master discovery and readiness probe. I think the sequence of events turns into a deadlock due to nature how elasticsearch-cloud-kubernetes plugin works using services for addressing the pods.

1) ES pods are started and waiting for readiness probe to succeed to include these pods in the ES service
2) ES containers try master discovery (requires network communication through the ES service)
3) ES service has no pods available to forward traffic, therefore master discovery is unable to happen and readiness probe never pronounces pods as healthy

This proposed change allows to define `pod_label` and `pod_port` for ES master discovery to bypass service completely and negotiate the protocol based on pods being correctly labeled.

So the configuration file would still support service based discovery, but it could also look like:
```
cloud:
  kubernetes:
    pod_label: component=es
    pod_port: 9300
    namespace: ${NAMESPACE}
```

While currently only this is accepted:
```
cloud:
  kubernetes:
    service: ${SERVICE_DNS}
    namespace: ${NAMESPACE}
```
